### PR TITLE
Fix codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: "6"
+node_js: "8"
 before_install:
   - pip install --user codecov
 after_success:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node start.js",
     "devStart": "nodemon start.js",
-    "test": "tape './src/test/*.js'"
+    "test": "npx nyc --reporter=lcov --reporter=text-summary tape './src/test/*.js'"
   },
   "repository": {
     "type": "git",
@@ -25,8 +25,8 @@
     "vision": "^4.1.1"
   },
   "devDependencies": {
-    "istanbul": "^0.4.5",
     "nodemon": "^1.11.0",
+    "nyc": "^15.0.1",
     "tape": "^4.6.3"
   }
 }


### PR DESCRIPTION
- Bump to node 8 (to be able to use npx)
- Update from istanbul to nyc

Travis: https://travis-ci.com/github/patkub/triumph-website/builds/163327486
The resulting codecov report: https://codecov.io/github/patkub/triumph-website/commit/82e11128582714f607bad63f33d44ade95378f2b

Closes #64 